### PR TITLE
Make header image absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Logo](/image/Elysium_Banner.png)
+![Logo](https://github.com/TitansBane/Elysium/raw/master/image/Elysium_Banner.png)
 
 # Elysium
 


### PR DESCRIPTION
Some Wabbajack tools are having issues resolving the relative path on the image, making this absolute would help